### PR TITLE
Support authenticate dns-controller through web-identity in GCP

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-v0.7.10-pingcap.1
+v0.7.10-pingcap.2.dev

--- a/charts/external-dns-management/templates/deployment.yaml
+++ b/charts/external-dns-management/templates/deployment.yaml
@@ -24,9 +24,26 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       containers:
+      {{- if .Values.gcpIdentity.enable }}
+      - name: auth
+        image: {{ .Values.gcpIdentity.image }}
+        env:
+          - name: AWS_WEB_IDENTITY_TOKEN_FILE
+            value: /identity/token
+        volumeMounts:
+          - mountPath: /identity
+            name: identity
+      {{- end }}
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.gcpIdentity.enable }}
+        env:
+        - name: AWS_WEB_IDENTITY_TOKEN_FILE
+          value: /identity/token
+        - name: AWS_ROLE_ARN
+          value: {{ .Values.gcpIdentity.roleArn }}
+        {{- end }}
         args:
         - --name={{ include "external-dns-management.fullname" . }}
         {{- if or .Values.configuration.identifier (not .Values.gardener.seed.identity) }}
@@ -584,16 +601,28 @@ spec:
         {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
+        {{- if or (.Values.configuration.persistentCache) (.Values.gcpIdentity.enable) }}
         {{- if .Values.configuration.persistentCache }}
         volumeMounts:
           - name: persistent-cache
             mountPath: /persistent-cache
         {{- end }}
-      {{- if .Values.configuration.persistentCache }}
+        {{- if .Values.gcpIdentity.enable }}
+          - name: identity
+            mountPath: /identity
+        {{- end }}
+        {{- end }}
+      {{- if or (.Values.configuration.persistentCache) (.Values.gcpIdentity.enable) }}
       volumes:
+      {{- if .Values.configuration.persistentCache }}
         - name: persistent-cache
           persistentVolumeClaim:
             claimName: {{ include "external-dns-management.fullname" . }}
+      {{- end }}
+      {{- if .Values.gcpIdentity.enable }}
+        - name: identity
+          emptyDir: {}
+      {{- end }}
       {{- end }}
       serviceAccountName: {{ include "external-dns-management.fullname" . }}
       {{- if .Values.priorityClassName }}

--- a/charts/external-dns-management/templates/deployment.yaml
+++ b/charts/external-dns-management/templates/deployment.yaml
@@ -602,8 +602,8 @@ spec:
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         {{- if or (.Values.configuration.persistentCache) (.Values.gcpIdentity.enable) }}
-        {{- if .Values.configuration.persistentCache }}
         volumeMounts:
+        {{- if .Values.configuration.persistentCache }}
           - name: persistent-cache
             mountPath: /persistent-cache
         {{- end }}

--- a/charts/external-dns-management/values.yaml
+++ b/charts/external-dns-management/values.yaml
@@ -23,6 +23,11 @@ affinity: {}
 
 createCRDs: true
 
+gcpIdentity:
+  enable: false
+  image: gcr.io/pingcap-gardener/jenkins/gcp-web-identity:20201201
+  roleArn: ""
+
 configuration:
   # alicloudDNSCacheTtl: 120
   # alicloudDNSDefaultPoolSize: 2


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

**What this PR does / why we need it**:

We use Route53 in GCP for gardener, so we need to support authenticate it with web-identity

**Special notes for your reviewer**:

Tested manually, given the following gardenlet configuration:

```
    overrideHelmValues:
      kind: HelmValues
      dns-external:
        gcpIdentity:
          enable: true
          image: gcr.io/pingcap-gardener/jenkins/gcp-web-identity:20201201
          roleArn: ******
```

The controller can works with sidecar seamlessly:
```
auth INFO:root:Issued token will be expired after 3600 seconds, refresh scheduled after 1800.0 seconds
seed-dns-controller-manager-7b5d55564b-6l8fx external-dns-management time="2020-12-21T05:19:47Z" level=info msg="Registering controller aws-route53"
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
