### PR TITLE
fix compile failed

### DIFF
--- a/pkg/dns/provider/provider.go
+++ b/pkg/dns/provider/provider.go
@@ -463,6 +463,10 @@ func (this *dnsProviderVersion) GetConfig() utils.Properties {
 	return this.account.config
 }
 
+func (this *dnsProviderVersion) GetZones() DNSHostedZones {
+	return this.zones
+}
+
 func (this *dnsProviderVersion) ones() DNSHostedZones {
 	return this.zones
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
```
➜  external-dns-management git:(e5e3709f) make docker-images
# github.com/gardener/external-dns-management/pkg/dns/provider
pkg/dns/provider/provider.go:265:5: cannot use &dnsProviderVersion{} (type *dnsProviderVersion) as type DNSProvider in assignment:
	*dnsProviderVersion does not implement DNSProvider (missing GetZones method)
pkg/dns/provider/state.go:244:13: cannot use p (type *dnsProviderVersion) as type DNSProvider in assignment:
	*dnsProviderVersion does not implement DNSProvider (missing GetZones method)
pkg/dns/provider/state.go:289:13: cannot use p (type *dnsProviderVersion) as type DNSProvider in assignment:
	*dnsProviderVersion does not implement DNSProvider (missing GetZones method)
pkg/dns/provider/state.go:391:23: cannot use this.providers[name] (type *dnsProviderVersion) as type DNSProvider in return argument:
	*dnsProviderVersion does not implement DNSProvider (missing GetZones method)
pkg/dns/provider/state.go:623:11: impossible type assertion:
	*dnsProviderVersion does not implement DNSProvider (missing GetZones method)
```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
